### PR TITLE
socketIO status indication on student side

### DIFF
--- a/clikr-client/src/services/SocketIOStudentService.js
+++ b/clikr-client/src/services/SocketIOStudentService.js
@@ -6,6 +6,12 @@ export default class SocketIOStudentService {
     constructor(store) {
         this.store = store;
         this.socket = socketIOClient(socketioURL);
+        this.timeout = null;
+        
+        store.setSocketIOStatus(true);  // optimistic approach: assume we're connected, verify later
+        setTimeout(() => {
+            this.checkConnection();
+        }, 1000)
     }
 
     reset() {
@@ -48,6 +54,27 @@ export default class SocketIOStudentService {
             this.store.updateAllQuestions(data.questions);
             console.log(data)
         });
+    }
+
+    // detect broken connection
+    startCheckingConnection() {
+        this.timeout = setInterval(() => {
+            this.checkConnection();
+        }, 1000);
+    }
+
+    // clear the timeout
+    stopCheckingConnection() {
+        clearTimeout(this.timeout);
+    }
+
+    // check if connected
+    checkConnection() {
+        if (this.socket.connected) {
+            this.store.setSocketIOStatus(true);
+        } else {
+            this.store.setSocketIOStatus(false);
+        }
     }
 
 }

--- a/clikr-client/src/stores/StudentStore.js
+++ b/clikr-client/src/stores/StudentStore.js
@@ -18,6 +18,14 @@ export default class StudentStore {
   @observable
   lastAnswer = null;  // the submitted answer to the most recently closed question
 
+  @observable
+  socketIOStatus = false;
+
+
+  @action
+  setSocketIOStatus(status) {
+    this.socketIOStatus = status;
+  }
 
   /** Call this when the question is closed and the component about to unmount.
    *  DO NOT call it when the student submits an answer!


### PR DESCRIPTION
- Detects disconnect and displays warning on student side.
- Detects reconnect.
- Displays "moving dots" when connection is alive.

However, it does not reload the open questions on reconnect.
Also, I was only able to test if it correctly detects the disconnection when I shut down the server. I'm not sure if it will detect the kind of disconnect that occurs on mobile when the browser tab is inactive for a while. 